### PR TITLE
Modified use of radius when rankby=distance is used.

### DIFF
--- a/lib/google-places.js
+++ b/lib/google-places.js
@@ -30,8 +30,8 @@ var GooglePlaces = function(key, options) {
 GooglePlaces.prototype.search = function(options, cb) {
   options = _.defaults(options, {
     location: [42.3577990, -71.0536364],
-    radius: 10,
     sensor: false,
+    radius: 10,
     language: 'en',
     types: []
   });
@@ -40,6 +40,10 @@ GooglePlaces.prototype.search = function(options, cb) {
 
   if (options.types.length > 0)
     options.types = options.types.join('|');
+
+  if(typeof(options.rankby) != 'undefined') 
+    if(options.rankby == 'distance')
+      options.radius = null;
   
   this._doRequest(this._generateUrl(options, 'search'), cb);
 };


### PR DESCRIPTION
When doing a place search where 'rankby=distance' parameter is used, radius needs to be excluded:

"Note that radius must not be included if rankby=distance (described under Optional parameters below) is specified."

and 

"Ranking results by distance will set a fixed search radius of 50km"

Added logic to check for the ranby param and adjust accordingly.
