### PR TITLE
Support for going through proxies

### DIFF
--- a/lib/google-places.js
+++ b/lib/google-places.js
@@ -1,6 +1,6 @@
-var https        = require('https'),
-    _            = require('underscore'),
-    url          = require('url');
+var _            = require('underscore'),
+    url          = require('url'),
+    request      = require('request');
 
 
 var GooglePlaces = function(key, options) {
@@ -20,7 +20,8 @@ var GooglePlaces = function(key, options) {
     headers: options.headers,
     host: options.host,
     port: options.port,
-    path: options.path
+    path: options.path,
+    proxy: options.proxy
   };
 
   return this;
@@ -73,24 +74,23 @@ GooglePlaces.prototype.details = function(options, cb) {
 // Run the request
 GooglePlaces.prototype._doRequest = function(request_query, cb) {
   // Pass the requested URL as an object to the get request
-  https.get(request_query, function(res) {
-      var data = [];
-      res
-      .on('data', function(chunk) { data.push(chunk); })
-      .on('end', function() {
-          var dataBuff = data.join('').trim();
-          var result;
-          try {
-            result = JSON.parse(dataBuff);
-          } catch (exp) {
-            result = {'status_code': 500, 'status_text': 'JSON Parse Failed'};
-          }
-          cb(null, result);
-      });
-  })
-  .on('error', function(e) {
-      cb(e);
+
+  var requestOptions = {};
+  requestOptions.url = request_query;
+  if(this.config.proxy){
+    requestOptions.proxy = this.config.proxy;
+  }
+
+  request(requestOptions, function (error, response, body) {
+    if (!error && response.statusCode == 200) {
+      var data = JSON.parse(body);
+      cb(null,data);
+    }
+    if(error){
+      cb(error,null);
+    }
   });
+
 };
 
 GooglePlaces.prototype._generateUrl = function(query, method) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "http://github.com/jpowers/node-google-places.git"
   },
-  "dependencies"  : ["underscore", "url"],
+  "dependencies"  : ["underscore", "url", "request"],
   "devDependencies": ["vows", "node-fakeweb"],
   "main": "./lib/google-places.js"
 }


### PR DESCRIPTION
Server-side requests for google places data will sometimes come through
a hosted cloud provider where outbound TCP requests are sent through
different IP ranges. Since Google has IP white listing there is a need
to have a static address for these requests. Using a proxy is the
typical solution to this.

I've added support for specifying a proxy parameter which simply calls
the node request library (and I've implictly added a dependency on the
request library).
