### PR TITLE
Fix https parsing of url

### DIFF
--- a/lib/google-places.js
+++ b/lib/google-places.js
@@ -75,17 +75,25 @@ GooglePlaces.prototype._doRequest = function(request_query, cb) {
   // Pass the requested URL as an object to the get request
   https.get(request_query, function(res) {
       var data = [];
+
+      if (res.statusCode >= 400) {
+        var e = new Error('Unexpected Google Places status code.');
+        e.statusCode = res.statusCode;
+        return cb(e);
+      }
+
       res
       .on('data', function(chunk) { data.push(chunk); })
       .on('end', function() {
-          var dataBuff = data.join('').trim();
-          var result;
+          var err, result;
           try {
-            result = JSON.parse(dataBuff);
+            result = JSON.parse(Buffer.concat(data).toString('utf8'));
           } catch (exp) {
-            result = {'status_code': 500, 'status_text': 'JSON Parse Failed'};
+            err = new Error('Failed to parse Google Places response.');
+            err.err = exp;
+            err.data = Buffer.concat(data);
           }
-          cb(null, result);
+          cb(err, result);
       });
   })
   .on('error', function(e) {
@@ -97,12 +105,12 @@ GooglePlaces.prototype._generateUrl = function(query, method) {
   //https://maps.googleapis.com/maps/api/place/search/json?
   _.compact(query); 
   query.key = this.config.key;
-  return url.parse(url.format({
+  return url.format({
     protocol: 'https',
     hostname: this.config.host,
     pathname: this.config.path + method + '/' + this.config.format,
     query: query
-  }));
+  });
 };
 
 module.exports = GooglePlaces;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 var GooglePlaces = require('../lib/google-places'),
     vows = require('vows'),
+    url = require('url'),
     fakeweb = require('node-fakeweb'),
     assert = require('assert');
 
@@ -21,20 +22,29 @@ fakeweb.registerUri({
   body: '{"result" : {"rating": 2.5}, "status" : "OK"}'
 });
 
+fakeweb.registerUri({
+  uri: 'https://maps.googleapis.com/maps/api/place/details/json?reference=ABC123&sensor=false&language=en&key=bad_key',
+  statusCode: 200,
+  body: '{"error_message" : "The provided API key is invalid.", "html_attributions" : [], "status" : "REQUEST_DENIED" }'
+});
+
 vows.describe('Url generation').addBatch({
   'default url': {
     topic: new GooglePlaces('fake_key'),
 
     'should have a default url for place search': function(topic) {
-      assert.equal(topic._generateUrl({}, 'search').href, 'https://maps.googleapis.com/maps/api/place/search/json?key=fake_key');
+      var targetUrl = url.parse(topic._generateUrl({}, 'search'));
+      assert.equal(targetUrl.href, 'https://maps.googleapis.com/maps/api/place/search/json?key=fake_key');
     },
 
     'should have a default url for place autocomplete': function(topic) {
-      assert.equal(topic._generateUrl({}, 'autocomplete').href, 'https://maps.googleapis.com/maps/api/place/autocomplete/json?key=fake_key');
+      var targetUrl = url.parse(topic._generateUrl({}, 'autocomplete'));
+      assert.equal(targetUrl.href, 'https://maps.googleapis.com/maps/api/place/autocomplete/json?key=fake_key');
     },
 
     'should have my key as a query param': function(topic) {
-      assert.equal(topic._generateUrl({key: 'fake_key'}, 'search').query, 'key=fake_key');
+      var targetUrl = url.parse(topic._generateUrl({key: 'fake_key'}, 'search'));
+      assert.equal(targetUrl.query, 'key=fake_key');
     }
   }
 }).export(module);


### PR DESCRIPTION
Fixes #17 
- `https` is returning `Buffer` objects, so just concatenate them on request complete.
- Use `url.format` to pass a complete href to `https`
